### PR TITLE
Fixes explore click tool bug with categorical variables

### DIFF
--- a/upstream/R/fct_Figures.R
+++ b/upstream/R/fct_Figures.R
@@ -1326,7 +1326,5 @@ get_plot_click_site_id <- function(
     siteId <- ''
   }
 
-  browser()
-
   return(siteId)
 }

--- a/upstream/R/fct_Figures.R
+++ b/upstream/R/fct_Figures.R
@@ -1162,20 +1162,8 @@ get_plot_click_site_id <- function(
     points <- points %>% dplyr::filter(!bad_match)
   }
 
-  # Helper function used to convert the categorical variable of fish passability
-  # to the x or y axis values on the scatterplot
-  convert_fish_passability <- function(variable) {
-    dplyr::case_when(
-      variable == "0%" ~ 1,
-      variable == "33%" ~ 2,
-      variable == "67%" ~ 3,
-      variable == "Unknown" ~ 4,
-      .default = NA_real_
-    )
-  }
-
-  categorical_x <- FALSE
-  categorical_y <- FALSE
+  is_categorical_x <- FALSE
+  is_categorical_y <- FALSE
 
   # Transform data for owner type into where on the scatterplot the axis is
   if (x_axis_variable == "owner_type_code") {
@@ -1195,7 +1183,7 @@ get_plot_click_site_id <- function(
           .default = NA_real_
         )
       )
-    categorical_x <- TRUE
+    is_categorical_x <- TRUE
   }
 
   if (y_axis_variable == "owner_type_code") {
@@ -1214,44 +1202,118 @@ get_plot_click_site_id <- function(
         .default = NA_real_
       )
     )
-    categorical_y <- TRUE
+    is_categorical_y <- TRUE
   }
 
-  # For percent passability, need to transform data into graph position
+  # Helper function used to convert the categorical variable of fish passability
+  # to the x or y axis values on the scatterplot
+  convert_fish_passability <- function(variable) {
+    dplyr::case_when(
+      variable == "0%" ~ 1,
+      variable == "33%" ~ 2,
+      variable == "67%" ~ 3,
+      variable == "Unknown" ~ 4,
+      .default = NA_real_
+    )
+  }
+
+  # For percent passability, transform data into graph position
   if (x_axis_variable %in% c("percent_fish_passable_code")) {
     points <- points %>%
       dplyr::mutate(
         X_var = convert_fish_passability(.data[[x_axis_variable]])
       )
-    categorical_x <- TRUE
+    is_categorical_x <- TRUE
   }
   if (y_axis_variable %in% c("percent_fish_passable_code")) {
     points <- points %>%
       dplyr::mutate(
         Y_var = convert_fish_passability(.data[[y_axis_variable]])
       )
-    categorical_y <- TRUE
+    is_categorical_y <- TRUE
+  }
+
+
+  # Fish species are handled differently since there is a many:1 mapping of
+  # fish species to culverts instead of a 1:1. We'll use the X or Y axis
+  # click target to identify which fish species they've selected, then fill in
+  # points$X_var or points$Y_var with that column number if that culvert has
+  # that fish species, or NA if that culvert does not.
+  get_species <- function(rounded_point) {
+    switch(
+      as.character(rounded_x_point),
+      "1" = "Bull Trout",
+      "2" = "Chinook",
+      "3" = "Chum",
+      "4" = "Coho",
+      "5" = "Pink",
+      "6" = "Resident Trout",
+      "7" = "Sockeye",
+      "8" = "SR Cutthroat",
+      "9" = "Steelhead"
+    )
+  }
+
+  # Helper function to update X_var or Y_var with appropriate categorical axis
+  # value or NA if that culvert does not contain that fish species
+  set_x_or_y_var_potential_species <- function(points, variable, rounded_point, column_name) {
+    if (rounded_point < 10) {
+      species <- get_species(rounded_point)
+      points <- points %>%
+        dplyr::mutate(
+          {{ column_name }} := ifelse(
+            grepl(species, .data[[variable]]),
+            rounded_point,
+            NA_real_
+          )
+        )
+    }
+    else {
+      points <- points %>%
+        dplyr::mutate(
+          {{ column_name }} := ifelse(
+            is.na(.data[[variable]]),
+            rounded_point,
+            NA_real_
+          )
+        )
+    }
+    return(points)
+  }
+
+  if (x_axis_variable == "potential_species") {
+    rounded_x_point <- round(plotClickX)
+    if (rounded_x_point == 0) {
+      rounded_x_point <- 1
+    }
+    points <- set_x_or_y_var_potential_species(points, "potential_species", rounded_x_point, "X_var")
+    is_categorical_x <- TRUE
+  }
+
+  if (y_axis_variable == "potential_species") {
+    rounded_y_point <- round(plotClickY)
+    if (rounded_y_point == 0) {
+      rounded_y_point <- 1
+    }
+    points <- set_x_or_y_var_potential_species(points, "potential_species", rounded_x_point, "Y_var")
+    is_categorical_y <- TRUE
   }
 
   # Adds X_var and Y_var for non-categorical variables
-  if (!categorical_x) {
+  if (!is_categorical_x) {
     points <- points %>%
       dplyr::mutate(X_var = as.numeric(.data[[x_axis_variable]]))
   }
-  if (!categorical_y) {
+  if (!is_categorical_y) {
     points <- points %>%
       dplyr::mutate(Y_var = as.numeric(.data[[y_axis_variable]]))
   }
 
   points <- points %>% dplyr::filter(!is.na(X_var) & !is.na(Y_var))
 
-  browser()
-
   # Calculate relative positions and differences
   max_X_var <- max(points$X_var, na.rm = TRUE)
   max_Y_var <- max(points$Y_var, na.rm = TRUE)
-
-  browser()
 
   points <- points %>%
     dplyr::mutate(RelX = X_var / max_X_var,
@@ -1259,8 +1321,6 @@ get_plot_click_site_id <- function(
                   Diff = sqrt((RelX - plotClickX / max_X_var)^2 + (RelY - plotClickY / max_Y_var)^2)) %>%
     dplyr::arrange(Diff) %>%
     dplyr::slice(1)
-
-  browser()
 
   # Check if click is close to a point
   if(nrow(points) > 0 && points$Diff[1] < .03){

--- a/upstream/R/fct_Figures.R
+++ b/upstream/R/fct_Figures.R
@@ -1163,45 +1163,49 @@ get_plot_click_site_id <- function(
   }
 
   is_categorical_x <- FALSE
+  rounded_x <- round(plotClickX)
+
   is_categorical_y <- FALSE
+  rounded_y <- round(plotClickY)
+
+  get_owner_column_name <- function(rounded_point) {
+    switch(
+      as.character(rounded_point),
+      "0" = "is_city",
+      "1" = "is_city",
+      "2" = "is_county",
+      "3" = "is_drainage_district",
+      "4" = "is_federal",
+      "5" = "is_multiple",
+      "6" = "is_other",
+      "7" = "is_private",
+      "8" = "is_state",
+      "9" = "is_tribal",
+      "10" = "is_unknown",
+      default = NA_real_
+    )
+  }
+
+  set_x_or_y_var_owner_type = function(points, rounded_point, column_name) {
+    variable_name <- get_owner_column_name(rounded_point)
+    points <- points %>%
+      dplyr::mutate(
+        {{ column_name }} := ifelse(
+          .data[[variable_name]],
+          rounded_point,
+          NA_real_
+        )
+      )
+  }
 
   # Transform data for owner type into where on the scatterplot the axis is
   if (x_axis_variable == "owner_type_code") {
-    points <- points %>%
-      dplyr::mutate(
-        X_var = dplyr::case_when(
-          .data[['is_city']] ~ 1,
-          .data[['is_county']] ~ 2,
-          .data[['is_drainage_district']] ~ 3,
-          .data[['is_federal']] ~ 4,
-          .data[['is_multiple']] ~ 5,
-          .data[['is_other']] ~ 6,
-          .data[['is_private']] ~ 7,
-          .data[['is_state']] ~ 8,
-          .data[['is_tribal']] ~ 9,
-          .data[['is_unknown']] ~ 10,
-          .default = NA_real_
-        )
-      )
+    set_x_or_y_var_owner_type(points, rounded_x, "X_var")
     is_categorical_x <- TRUE
   }
 
   if (y_axis_variable == "owner_type_code") {
-    dplyr::mutate(
-      Y_var = dplyr::case_when(
-        .data[['is_city']] ~ 1,
-        .data[['is_county']] ~ 2,
-        .data[['is_drainage_district']] ~ 3,
-        .data[['is_federal']]  ~ 4,
-        .data[['is_multiple']] ~ 5,
-        .data[['is_other']] ~ 6,
-        .data[['is_private']] ~ 7,
-        .data[['is_state']] ~ 8,
-        .data[['is_tribal']] ~ 9,
-        .data[['is_unknown']] ~ 10,
-        .default = NA_real_
-      )
-    )
+    set_x_or_y_var_owner_type(points, rounded_y, "Y_var")
     is_categorical_y <- TRUE
   }
 
@@ -1233,7 +1237,6 @@ get_plot_click_site_id <- function(
     is_categorical_y <- TRUE
   }
 
-
   # Fish species are handled differently since there is a many:1 mapping of
   # fish species to culverts instead of a 1:1. We'll use the X or Y axis
   # click target to identify which fish species they've selected, then fill in
@@ -1241,7 +1244,8 @@ get_plot_click_site_id <- function(
   # that fish species, or NA if that culvert does not.
   get_species <- function(rounded_point) {
     switch(
-      as.character(rounded_x_point),
+      as.character(rounded_point),
+      "0" = "Bull Trout",
       "1" = "Bull Trout",
       "2" = "Chinook",
       "3" = "Chum",
@@ -1282,22 +1286,16 @@ get_plot_click_site_id <- function(
   }
 
   if (x_axis_variable == "potential_species") {
-    rounded_x_point <- round(plotClickX)
-    if (rounded_x_point == 0) {
-      rounded_x_point <- 1
-    }
-    points <- set_x_or_y_var_potential_species(points, "potential_species", rounded_x_point, "X_var")
+    points <- set_x_or_y_var_potential_species(points, "potential_species", rounded_x, "X_var")
     is_categorical_x <- TRUE
   }
 
   if (y_axis_variable == "potential_species") {
-    rounded_y_point <- round(plotClickY)
-    if (rounded_y_point == 0) {
-      rounded_y_point <- 1
-    }
-    points <- set_x_or_y_var_potential_species(points, "potential_species", rounded_x_point, "Y_var")
+    points <- set_x_or_y_var_potential_species(points, "potential_species", rounded_y, "Y_var")
     is_categorical_y <- TRUE
   }
+
+  browser()
 
   # Adds X_var and Y_var for non-categorical variables
   if (!is_categorical_x) {
@@ -1328,6 +1326,8 @@ get_plot_click_site_id <- function(
   } else {
     siteId <- ''
   }
+
+  browser()
 
   return(siteId)
 }

--- a/upstream/R/fct_Figures.R
+++ b/upstream/R/fct_Figures.R
@@ -1196,16 +1196,17 @@ get_plot_click_site_id <- function(
           NA_real_
         )
       )
+    return(points)
   }
 
   # Transform data for owner type into where on the scatterplot the axis is
   if (x_axis_variable == "owner_type_code") {
-    set_x_or_y_var_owner_type(points, rounded_x, "X_var")
+    points <- set_x_or_y_var_owner_type(points, rounded_x, "X_var")
     is_categorical_x <- TRUE
   }
 
   if (y_axis_variable == "owner_type_code") {
-    set_x_or_y_var_owner_type(points, rounded_y, "Y_var")
+    points <- set_x_or_y_var_owner_type(points, rounded_y, "Y_var")
     is_categorical_y <- TRUE
   }
 
@@ -1294,8 +1295,6 @@ get_plot_click_site_id <- function(
     points <- set_x_or_y_var_potential_species(points, "potential_species", rounded_y, "Y_var")
     is_categorical_y <- TRUE
   }
-
-  browser()
 
   # Adds X_var and Y_var for non-categorical variables
   if (!is_categorical_x) {

--- a/upstream/R/mod_Figures.R
+++ b/upstream/R/mod_Figures.R
@@ -53,7 +53,7 @@ mod_Figures_server <- function(id, r){
 
     # Explore submit button event for base_map
     observeEvent(r$submit_explore, {
-      
+
       update_map_selected_polygons(
         leaflet::leafletProxy(ns('base_map')),
         r$area_sel_explore,
@@ -359,8 +359,8 @@ mod_Figures_server <- function(id, r){
       if(r$tab_sel == 'Explore'){
         if(r$plot_type_explore == 'histogram'){
           r$plot_click_text_output <- ''
-        } else if(r$x_axis_variable_explore %in% c("potential_species", "owner_type_code", "percent_fish_passable_code") | r$y_axis_variable_explore %in% c("potential_species", "owner_type_code", "percent_fish_passable_code")){
-          r$plot_click_text_output_explore <- ''
+        ##} else if(r$x_axis_variable_explore %in% c("potential_species", "owner_type_code", "percent_fish_passable_code") | r$y_axis_variable_explore %in% c("potential_species", "owner_type_code", "percent_fish_passable_code")){
+          ## r$plot_click_text_output_explore <- ''
         } else {
           if(r$remove_bad_match_explore){
           r$plot_click_text_output_explore <- get_plot_click_site_id(
@@ -373,7 +373,7 @@ mod_Figures_server <- function(id, r){
             culverts_cmb,
             r$owner_sel_explore, r$area_sel_explore, r$remove_bad_match_explore, r$x_axis_variable_explore,
             r$y_axis_variable_explore, input$plot_click$x, input$plot_click$y
-            )  
+            )
           }
         }
       }

--- a/upstream/R/mod_Figures.R
+++ b/upstream/R/mod_Figures.R
@@ -359,8 +359,6 @@ mod_Figures_server <- function(id, r){
       if(r$tab_sel == 'Explore'){
         if(r$plot_type_explore == 'histogram'){
           r$plot_click_text_output <- ''
-        ##} else if(r$x_axis_variable_explore %in% c("potential_species", "owner_type_code", "percent_fish_passable_code") | r$y_axis_variable_explore %in% c("potential_species", "owner_type_code", "percent_fish_passable_code")){
-          ## r$plot_click_text_output_explore <- ''
         } else {
           if(r$remove_bad_match_explore){
           r$plot_click_text_output_explore <- get_plot_click_site_id(


### PR DESCRIPTION
Fixes the click tool so it can identify culverts for categorical variables. 

I recommend viewing the code files for this PR with whitespace changes turned off.

Note: this solution does rely on hard-coding which column index each variable is assigned to in the histogram. If we add a fish species or get data points for owner types not currently represented in the data (for example: Port), we would need to update these lines.

You can find videos displaying the functionality for each categorical variable [here](https://drive.google.com/drive/folders/1_fIC-djdw6Fc9PuTVJdsR9fsKAKaY7IN?usp=drive_link).